### PR TITLE
fix typo ebPhone

### DIFF
--- a/public/template.html
+++ b/public/template.html
@@ -245,7 +245,7 @@
                 alt="phone with emphatic building on the screen"
                 id="cardImagePhone"
                 class="cardImage"
-                src="assets/ebSection/ebphone.webp"
+                src="assets/ebSection/ebPhone.webp"
               />
             </div>
 


### PR DESCRIPTION
ebPhone did not render because of a typo on it's name. 

the name was written in all lowercase

fixed it by writing it in camel case 